### PR TITLE
Feat/hide specific notifications

### DIFF
--- a/css/feed.css
+++ b/css/feed.css
@@ -1,5 +1,6 @@
 .org-organization-admin-pages-entrypoint-card__card,
 .feed-identity-module__widgets,
-.artdeco-toast-item--visible {
+.artdeco-toast-item--visible,
+.feed-new-update-pill__new-update-button {
   display: none !important;
 }

--- a/css/feed.css
+++ b/css/feed.css
@@ -1,4 +1,5 @@
 .org-organization-admin-pages-entrypoint-card__card,
-.feed-identity-module__widgets {
+.feed-identity-module__widgets,
+.artdeco-toast-item--visible {
   display: none !important;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This change hides two notifications that seem to only appear on the home page. 


<!--- Describe your changes in detail -->

## Background

The name of this browser extension is "Hide LinkedIn Profile Stats." But as I've been using LinkedIn lately I've noticed how obtrusive certain alerts are that can only be manually dismissed. Two examples are the "New Posts" button that appears at the top of the feed after scrolling for a while and the notification in the bottom-left of the page after completing certain actions, like writing a post.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can load the browser extension after `git clone`-ing the repo and following the instructions in the README. 
When on LinkedIn, even after scrolling through the feed for a while, you should never see the "new posts" button appear. After making posts or comments you should never see the bottom-left notification appear, either. 

<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
