### PR TITLE
Feat/hide post stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
 # No LinkedIn Profile Stats
 
 ## Abstract
-This browser extension hides the page view and post impression statistics on LinkedIn.
+
+This browser extension hides the following on LinkedIn:
+
+- page view statistics
+- post impression statistics
+- like counts on individual posts
+- people you may know section on individual profiles
+- people also viewed section on individual profiles
+- new posts button at top of feed visible after scrolling for a while
+- notification at bottom-left of page after completing certain tasks like writing a post.
 
 ## Tech Stack
+
 This project uses vanilla JS, CSS, and HTML.
 
 ## Setup/Installation
+
 You can clone the repo locally using `git clone`.
 
 [This article](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked) offers detailed instructions on loading an unpacked chrome extension. You can navigate to the chrome extensions page via the puzzle piece icon in the toolbar. Enable "developer mode" on the top-right. From there, you can click "load unpacked extension" and choose the folder via the popup. You should then see the chart icon appear in the toolbar. When you click on it, you can see "Hide LinkedIn Profile Stats." If you navigate to `linkedin.com/feed` while logged in, on the left-hand side of the page you should no longer see "Impressions of your post" or "Profile views." If you have a business account, you should no longer see "Page notifications" or "Page visitors" on the left-hand side, either. If you navigate to your profile page (url should include `linkedin.com/in`) or someone else's, on the right-hand side of the page you should no longer see suggestions of people or pages to follow.
-
-
-

--- a/css/global.css
+++ b/css/global.css
@@ -4,7 +4,11 @@
 .feed-new-update-pill__new-update-button,
 aside > section.artdeco-card.ember-view.relative.break-words.pb3.mt2,
 .pv-profile-pymk__container,
-.pvs-loader__profile-card
-{
+.pvs-loader__profile-card {
   display: none !important;
+}
+
+/* using visibility hidden to preserve the existing structure with comments on the bottom right-hand side of each post */
+li.social-details-social-counts__reactions {
+  visibility: hidden !important;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide LinkedIn Profile Stats",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Hide LinkedIn statistics related to page views and post impressions",
    "permissions": ["scripting"],
   "icons": {

--- a/popup.html
+++ b/popup.html
@@ -1,6 +1,28 @@
-<html>
-    <body>
-        <h2>Hide LinkedIn Profile Stats</h2>
-        <script src="popup.js" type="module"></script>
-    </body>
+<html class="popup-window" style="width: 200px">
+  <body>
+    <h2>Hide LinkedIn Profile Stats</h2>
+    <p>
+      version: 0.0.3 |
+      <a
+        href="https://github.com/garnetred/hide-linkedin-profile-stats"
+        style="color: navy"
+        target="_blank"
+        rel="noopener noreferrer"
+        >github</a
+      >
+    </p>
+    <script src="popup.js" type="module"></script>
+    <p style="color: gray">
+      Loving this extension? <br />
+      Consider
+      <a
+        href="https://www.buymeacoffee.com/decemberthedeveloper"
+        style="font-weight: bold; color: navy"
+        target="_blank"
+        rel="noopener noreferrer"
+        >buying me a coffee</a
+      >
+      to support my work.
+    </p>
+  </body>
 </html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This hides the like count on each post. 

**If you don't want to hide the like count you should continue using version 0.0.1 or 0.0.2.** 

<!--- Describe your changes in detail -->

## Background
Personally I find like counts to be distracting and I experience less anxiety if the counts aren't visible. This update removes the like count from posts in the feed and on a user's individual linkedin page. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can `git clone` this extension and switch to this branch. From there, you can load the unpacked extension into your Chromium-based browser. Afterwards, you can navigate to linkedin.com/feed. You should not see any like counts at all. 

<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [x] I have updated any relevant documentation.
