### PR TITLE
Hide profile stats sidebar

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -22,3 +22,8 @@ a[href="/mynetwork/network-manager/people-follow/followers/"] {
 .ca-entry-point__num-views > strong {
   visibility: hidden !important;
 }
+
+/* hides profile stats in left hand sidebar */
+.feed-left-nav-growth-widgets__widgets {
+  display: none !important;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide LinkedIn Profile Stats",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Hide LinkedIn statistics related to page views and post impressions",
    "permissions": ["scripting"],
   "icons": {

--- a/popup.html
+++ b/popup.html
@@ -2,7 +2,7 @@
   <body>
     <h2>Hide LinkedIn Profile Stats</h2>
     <p>
-      version: 0.0.4 |
+      version: 0.0.5 |
       <a
         href="https://github.com/garnetred/hide-linkedin-profile-stats"
         style="color: navy"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This PR hides the profile stats sidebar.
<!--- Describe your changes in detail -->

## Background
The code for the sidebar changed, so this PR references the new class name to remove the sidebar from the DOM.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can git clone the repo, switch to this branch, and load the extension in Chrome as an unpacked extension in developer mode. Then on the LinkedIn home page you shouldn't see any statistics about the number of people who've viewed your profile. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
- [x] I have incremented the version number in the manifest.json file.
- [x] I have updated the version number in the popup.html file.
